### PR TITLE
Adapt FLAFL for GitHub webhooks and Jira integration

### DIFF
--- a/flafl/__init__.py
+++ b/flafl/__init__.py
@@ -1,75 +1,82 @@
 """
-Main package.
+FLAFL - Flask Application For Listening (to GitHub webhooks)
 
-Define the end points of the REST API; delegate responses to strategies
+Listens for GitHub webhook events and updates Jira tickets accordingly.
+Supports PR lifecycle events: opened, closed/merged, synchronized, reviewed.
 """
+
 import json
 import os
 
 from flask import Flask, jsonify, request
 
-from . import bamboo
 from . import context
-from . import helpers
-from . import strategies
 from . import exceptions
+from . import github
+from . import helpers
+from . import jira
 from . import jsonparser
+from . import strategies
 
-USER_HOME = os.environ["HOME"]
 
-try:
-    NETRC_FILE = os.environ["NETRC_FILE"]
-except KeyError:
-    print("ERROR: Location of netrc file for Bamboo credentials not specified")
-    NETRC_FILE = None
+# Configuration from environment variables
+def get_env(key, default=None, required=False):
+    """Get environment variable with optional default."""
+    value = os.environ.get(key, default)
+    if required and value is None:
+        print(f"ERROR: {key} not specified")
+    return value
 
-try:
-    BAMB_HOSTNAME = os.environ["BAMB_HOSTNAME"]
-except KeyError:
-    print("ERROR: Bamboo hostname not specified")
-    BAMB_HOSTNAME = None
 
-try:
-    BITB_HOSTNAME = os.environ["BITB_HOSTNAME"]
-except KeyError:
-    print("ERROR: Bitbucket hostname not specified")
-    BITB_HOSTNAME = None
+# Jira configuration
+JIRA_BASE_URL = get_env("JIRA_BASE_URL", required=True)
+JIRA_USER_EMAIL = get_env("JIRA_USER_EMAIL", required=True)
+JIRA_API_TOKEN = get_env("JIRA_API_TOKEN", required=True)
 
-try:
-    BITB_PROJECT = os.environ["BITB_PROJECT"]
-except KeyError:
-    print("ERROR: Bitbucket project name not specified")
-    BITB_PROJECT = None
+# GitHub configuration (for commenting on PRs)
+GITHUB_TOKEN = get_env("GITHUB_TOKEN", required=True)
 
-try:
-    BITB_REPO = os.environ["BITB_REPO"]
-except KeyError:
-    print("ERROR: Bitbucket repository name not specified")
-    BITB_REPO = None
+# Webhook secret for verifying GitHub signatures (optional but recommended)
+WEBHOOK_SECRET = get_env("WEBHOOK_SECRET")
 
+# Status transition configuration (customize for your Jira workflow)
+CONFIG = {
+    # Status to transition to when PR is opened
+    "status_on_pr_opened": get_env("STATUS_ON_PR_OPENED", "In Review"),
+    # Status to transition to when PR is merged
+    "status_on_pr_merged": get_env("STATUS_ON_PR_MERGED", "Done"),
+    # Status to transition to when PR is closed without merge (optional)
+    "status_on_pr_declined": get_env("STATUS_ON_PR_DECLINED"),
+    # Status to transition to when review is approved (optional)
+    "status_on_review_approved": get_env("STATUS_ON_REVIEW_APPROVED"),
+    # Status to transition to when changes are requested (optional)
+    "status_on_changes_requested": get_env("STATUS_ON_CHANGES_REQUESTED"),
+    # Whether to add Jira comments when PR is synchronized
+    "comment_on_pr_sync": get_env("COMMENT_ON_PR_SYNC", "false").lower() == "true",
+}
+
+# Initialize connections
 conns = {}
-try:
-    conns["bamb"] = bamboo.BambooConnection(NETRC_FILE, BAMB_HOSTNAME)
-except FileNotFoundError:
-    print("ERROR: netrc file not found")
-    conns["bamb"] = None
 
 try:
-    conns["bitb"] = bamboo.BambooConnection(NETRC_FILE, BITB_HOSTNAME)
-except FileNotFoundError:
-    print("ERROR: netrc file not found")
-    conns["bitb"] = None
+    if JIRA_BASE_URL and JIRA_USER_EMAIL and JIRA_API_TOKEN:
+        conns["jira"] = jira.JiraConnection(JIRA_BASE_URL, JIRA_USER_EMAIL, JIRA_API_TOKEN)
+    else:
+        conns["jira"] = None
+        print("WARNING: Jira connection not configured")
+except Exception as e:
+    print(f"ERROR: Failed to create Jira connection: {e}")
+    conns["jira"] = None
 
-## TODO: temporary checks until in routine use --------------------------------
-## Check contact with Bamboo. (Just make a simple GET API call that lists all projects.)
-# response = conns["bamb"].get("project.json")
-# assert response.status_code == 200
-# helpers.log(json.dumps(response.json(), sort_keys=True, indent=4))
-## Check contact with Bitbucket. (Just make a simple GET API call that lists all projects.)
-# response = conns["bitb"].get("projects", apiversion="1.0")
-# assert response.status_code == 200
-# helpers.log(json.dumps(response.json(), sort_keys=True, indent=4))
-# ----------------------------------------------------------------------------
+try:
+    if GITHUB_TOKEN:
+        conns["github"] = github.GitHubConnection(GITHUB_TOKEN)
+    else:
+        conns["github"] = None
+        print("WARNING: GitHub connection not configured")
+except Exception as e:
+    print(f"ERROR: Failed to create GitHub connection: {e}")
+    conns["github"] = None
 
 
 app = Flask(__name__)
@@ -85,65 +92,102 @@ def handle_invalid_usage(error):
 
 @app.route("/flafl/api/v1.0/events", methods=["POST"])
 def post_event():
+    """
+    Main webhook endpoint for GitHub events.
+
+    GitHub sends the event type in the X-GitHub-Event header.
+    The action (opened, closed, etc.) is in the JSON payload.
+    """
     debug_info = {}
-    debug_info["payloadReceived"] = request.json
+    debug_info["payload_received"] = request.json
 
-    # Verbose
-    # helpers.log(json.dumps(request.json, sort_keys=True, indent=4))
+    # Get the GitHub event type from header
+    github_event = request.headers.get("X-GitHub-Event")
+    debug_info["github_event"] = github_event
 
-    # For 'Test Connection' function in Bamboo webhook settings
-    if jsonparser.is_connection_test(request.json):
-        message = "Successful connection."
-        return jsonify({"message": message, "debug_info": debug_info})
+    # Handle ping events (webhook setup verification)
+    if github_event == "ping" or jsonparser.is_ping_event(request.json):
+        concrete_strategy = strategies.Ping()
+        ct = context.Context(concrete_strategy)
+        return ct.execute_strategy(request.json, debug_info, conns, CONFIG)
 
-    event_key, event_trigger = jsonparser.get_event_key(request.json, debug_info)
+    # Get event type and action
+    event_type, action = jsonparser.get_event_type(
+        request.json, github_event, debug_info
+    )
+    debug_info["event_type"] = event_type
+    debug_info["action"] = action
 
-    debug_info["eventKey"] = event_key
-    debug_info["eventTrigger"] = event_trigger
-
-    # Select the appropriate strategy
-    if event_key.startswith("pr:"):
-        if event_trigger == "opened":
-            concrete_strategy = strategies.PrCreate()
-
-        if event_trigger == "deleted":
-            concrete_strategy = strategies.PrDestroy()
-
-        if event_trigger == "merged":
-            concrete_strategy = strategies.PrDestroy()
-
-        if event_trigger == "declined":
-            concrete_strategy = strategies.PrDestroy()
-
-        if event_trigger == "modified":
-            concrete_strategy = strategies.PrModify()
-
-        if event_trigger == "comment":
-            concrete_strategy = strategies.PrComment()
-
-    if event_key.startswith("repo:"):
-        if event_trigger == "refs_changed":
-            concrete_strategy = strategies.RepoPush()
-
-        else:
-            concrete_strategy = strategies.RepoAll()
+    # Route to appropriate strategy based on event type and action
+    concrete_strategy = select_strategy(event_type, action)
 
     # Execute the strategy
-    try:
-        ct = context.Context(concrete_strategy)
-    except UnboundLocalError:
-        message = "Trigger-handling for eventKey not coded yet"
-        payload = {"eventKey": event_key}
-        success_payload = {"message": message, "payload": payload}
-    else:
-        return_value = ct.execute_strategy(request.json, debug_info, conns)
-        success_payload = return_value.get_json()
+    ct = context.Context(concrete_strategy)
+    result = ct.execute_strategy(request.json, debug_info, conns, CONFIG)
 
+    # Log the result
     try:
         helpers.log(
-            "Success payload:\n" + json.dumps(success_payload, sort_keys=True, indent=4)
+            f"Event: {event_type}/{action}\n"
+            + json.dumps(result.get_json(), sort_keys=True, indent=2)
         )
-    except TypeError:
+    except (TypeError, AttributeError):
         pass
 
-    return jsonify(success_payload)
+    return result
+
+
+def select_strategy(event_type, action):
+    """
+    Select the appropriate strategy based on GitHub event type and action.
+
+    Args:
+        event_type: GitHub event type (pull_request, pull_request_review, etc.)
+        action: Event action (opened, closed, synchronize, submitted, etc.)
+
+    Returns:
+        Strategy instance
+    """
+    # Pull request events
+    if event_type == "pull_request":
+        if action == "opened" or action == "reopened":
+            return strategies.PrOpened()
+        elif action == "closed":
+            return strategies.PrClosed()
+        elif action == "synchronize":
+            return strategies.PrSynchronize()
+        # edited, assigned, unassigned, etc. - currently unhandled
+        else:
+            return strategies.Unhandled()
+
+    # Pull request review events
+    elif event_type == "pull_request_review":
+        if action == "submitted":
+            return strategies.PrReviewSubmitted()
+        else:
+            return strategies.Unhandled()
+
+    # Issue comment events (includes PR comments)
+    elif event_type == "issue_comment":
+        if action == "created":
+            return strategies.PrComment()
+        else:
+            return strategies.Unhandled()
+
+    # Push events
+    elif event_type == "push":
+        return strategies.Push()
+
+    # Unhandled event type
+    else:
+        return strategies.Unhandled()
+
+
+@app.route("/flafl/api/v1.0/health", methods=["GET"])
+def health_check():
+    """Health check endpoint."""
+    return jsonify({
+        "status": "healthy",
+        "jira_connected": conns.get("jira") is not None,
+        "github_connected": conns.get("github") is not None,
+    })

--- a/flafl/context.py
+++ b/flafl/context.py
@@ -1,4 +1,4 @@
-"""Context module."""
+"""Context module for Strategy pattern."""
 
 
 class Context:
@@ -8,7 +8,9 @@ class Context:
         """Maintain a reference to a Strategy object."""
         self._strategy = strategy
 
-    def execute_strategy(self, json_data, debug_info, conns):
+    def execute_strategy(self, json_data, debug_info, conns, config=None):
         """Execute wrapper for the Strategy object's execute method."""
-        return_value = self._strategy.execute(json_data, debug_info, conns)
+        if config is None:
+            config = {}
+        return_value = self._strategy.execute(json_data, debug_info, conns, config)
         return return_value

--- a/flafl/github.py
+++ b/flafl/github.py
@@ -1,0 +1,78 @@
+"""GitHub API client for interacting with pull requests."""
+
+import requests
+
+
+class GitHubConnection:
+    """Connection to GitHub API."""
+
+    def __init__(self, token):
+        """
+        Create the connection using a GitHub token.
+
+        Args:
+            token: GitHub personal access token or GitHub App token
+        """
+        self.token = token
+        self.api_url = "https://api.github.com"
+        self.headers = {
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+
+    def add_pr_comment(self, owner, repo, pr_number, comment_text):
+        """
+        Add a comment to a pull request.
+
+        Args:
+            owner: Repository owner (user or organization)
+            repo: Repository name
+            pr_number: Pull request number
+            comment_text: Comment text to add
+
+        Returns:
+            Response object with created comment
+        """
+        response = requests.post(
+            url=f"{self.api_url}/repos/{owner}/{repo}/issues/{pr_number}/comments",
+            headers=self.headers,
+            json={"body": comment_text},
+        )
+        return response
+
+    def get_pr(self, owner, repo, pr_number):
+        """
+        Get pull request details.
+
+        Args:
+            owner: Repository owner
+            repo: Repository name
+            pr_number: Pull request number
+
+        Returns:
+            Response object with PR data
+        """
+        response = requests.get(
+            url=f"{self.api_url}/repos/{owner}/{repo}/pulls/{pr_number}",
+            headers=self.headers,
+        )
+        return response
+
+    def get_pr_commits(self, owner, repo, pr_number):
+        """
+        Get commits in a pull request.
+
+        Args:
+            owner: Repository owner
+            repo: Repository name
+            pr_number: Pull request number
+
+        Returns:
+            Response object with commit list
+        """
+        response = requests.get(
+            url=f"{self.api_url}/repos/{owner}/{repo}/pulls/{pr_number}/commits",
+            headers=self.headers,
+        )
+        return response

--- a/flafl/helpers.py
+++ b/flafl/helpers.py
@@ -1,35 +1,122 @@
-import datetime  # for log only
-import re
+"""Helper functions for GitHub/Jira integration."""
+
+import datetime
 
 
 def log(log_entry):
+    """Write a log entry to the log file."""
     with open(__package__ + ".log", "a") as file_pointer:
         file_pointer.write(str(datetime.datetime.now()) + "\n")
         file_pointer.write(log_entry)
         file_pointer.write("\n")
 
 
-def check_for_jira_ticket(
-    conns, to_ref_proj, to_ref_slug, pull_request_id, pull_request_title
-):
-    JIRA_TICKET_REGEX = re.compile(to_ref_proj + "-[0-9]+")
-    # PR ID 1 is used for testing
-    if pull_request_id != "1" and not JIRA_TICKET_REGEX.match(pull_request_title):
-        comment = (
-            "Please add a Jira ticket ID to the pull request title. E.g. 'JIRA-123: "
-            + pull_request_title
-            + "'"
+def add_missing_jira_comment(conns, pr_info):
+    """
+    Add a comment to the PR asking for a Jira ticket reference.
+
+    Args:
+        conns: Dict of connections (github, jira)
+        pr_info: Dict with PR information (repo_owner, repo_name, number, title)
+    """
+    github_conn = conns.get("github")
+    if not github_conn:
+        log("ERROR: No GitHub connection - cannot add comment")
+        return
+
+    comment = (
+        "This pull request doesn't appear to reference a Jira ticket. "
+        "Please include the Jira issue key in the PR title or description "
+        "(e.g., `PROJ-123: Add new feature`).\n\n"
+        "This helps us automatically track progress in Jira."
+    )
+
+    try:
+        response = github_conn.add_pr_comment(
+            pr_info["repo_owner"],
+            pr_info["repo_name"],
+            pr_info["number"],
+            comment,
         )
-        try:
-            conns["bitb"].post(
-                "projects/"
-                + to_ref_proj
-                + "/repos/"
-                + to_ref_slug
-                + "/pull-requests/"
-                + str(pull_request_id)
-                + "/comments",
-                json={"text": comment},
-            )
-        except AttributeError:
-            print("ERROR: no Bitbucket connection")
+        if response.status_code == 201:
+            log(f"Added missing Jira comment to PR #{pr_info['number']}")
+        else:
+            log(f"Failed to add comment: {response.status_code} - {response.text}")
+    except Exception as e:
+        log(f"ERROR adding comment to PR: {e}")
+
+
+def transition_jira_issue(conns, issue_key, target_status, pr_info):
+    """
+    Transition a Jira issue to a target status and add a comment.
+
+    Args:
+        conns: Dict of connections (github, jira)
+        issue_key: Jira issue key (e.g., PROJ-123)
+        target_status: Target status name (e.g., "In Review", "Done")
+        pr_info: Dict with PR information
+
+    Returns:
+        Tuple of (success: bool, message: str)
+    """
+    jira_conn = conns.get("jira")
+    if not jira_conn:
+        msg = f"No Jira connection - cannot transition {issue_key}"
+        log(f"ERROR: {msg}")
+        return False, msg
+
+    # First, add a comment about the PR
+    pr_url = pr_info.get("html_url", "")
+    pr_number = pr_info.get("number", "")
+    pr_title = pr_info.get("title", "")
+
+    comment = f"PR #{pr_number} ({pr_title}) - transitioning to {target_status}\n{pr_url}"
+
+    try:
+        jira_conn.add_comment(issue_key, comment)
+    except Exception as e:
+        log(f"Warning: Could not add comment to {issue_key}: {e}")
+
+    # Then transition the issue
+    try:
+        success, msg = jira_conn.transition_to_status(issue_key, target_status)
+        log(f"Jira transition for {issue_key}: {msg}")
+        return success, msg
+    except Exception as e:
+        msg = f"Failed to transition {issue_key}: {e}"
+        log(f"ERROR: {msg}")
+        return False, msg
+
+
+def add_jira_comment(conns, issue_key, comment_text):
+    """
+    Add a comment to a Jira issue.
+
+    Args:
+        conns: Dict of connections
+        issue_key: Jira issue key
+        comment_text: Comment text to add
+
+    Returns:
+        Tuple of (success: bool, message: str)
+    """
+    jira_conn = conns.get("jira")
+    if not jira_conn:
+        msg = f"No Jira connection - cannot add comment to {issue_key}"
+        log(f"ERROR: {msg}")
+        return False, msg
+
+    try:
+        response = jira_conn.add_comment(issue_key, comment_text)
+        if response.status_code == 201:
+            msg = f"Added comment to {issue_key}"
+            log(msg)
+            return True, msg
+        else:
+            msg = f"Failed to add comment to {issue_key}: {response.status_code}"
+            log(f"ERROR: {msg}")
+            return False, msg
+    except Exception as e:
+        msg = f"Failed to add comment to {issue_key}: {e}"
+        log(f"ERROR: {msg}")
+        return False, msg

--- a/flafl/jira.py
+++ b/flafl/jira.py
@@ -1,0 +1,155 @@
+"""Jira API client for transitioning issues."""
+
+import requests
+
+
+class JiraConnection:
+    """Connection to Jira Cloud for API calls."""
+
+    def __init__(self, base_url, email, api_token):
+        """
+        Create the connection using email and API token.
+
+        Args:
+            base_url: Jira instance URL (e.g., https://your-org.atlassian.net)
+            email: User email for authentication
+            api_token: Jira API token (generate at https://id.atlassian.com/manage-profile/security/api-tokens)
+        """
+        self.auth = (email, api_token)
+        self.base_url = base_url.rstrip("/")
+        self.api_url = f"{self.base_url}/rest/api/3"
+        self.headers = {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        }
+
+    def get_issue(self, issue_key):
+        """
+        Get issue details.
+
+        Args:
+            issue_key: Jira issue key (e.g., PROJ-123)
+
+        Returns:
+            Response object with issue data
+        """
+        response = requests.get(
+            url=f"{self.api_url}/issue/{issue_key}",
+            auth=self.auth,
+            headers=self.headers,
+        )
+        return response
+
+    def get_transitions(self, issue_key):
+        """
+        Get available transitions for an issue.
+
+        Args:
+            issue_key: Jira issue key (e.g., PROJ-123)
+
+        Returns:
+            Response object with available transitions
+        """
+        response = requests.get(
+            url=f"{self.api_url}/issue/{issue_key}/transitions",
+            auth=self.auth,
+            headers=self.headers,
+        )
+        return response
+
+    def transition_issue(self, issue_key, transition_id):
+        """
+        Transition an issue to a new status.
+
+        Args:
+            issue_key: Jira issue key (e.g., PROJ-123)
+            transition_id: ID of the transition to execute
+
+        Returns:
+            Response object (204 on success)
+        """
+        payload = {"transition": {"id": str(transition_id)}}
+        response = requests.post(
+            url=f"{self.api_url}/issue/{issue_key}/transitions",
+            auth=self.auth,
+            headers=self.headers,
+            json=payload,
+        )
+        return response
+
+    def add_comment(self, issue_key, comment_text):
+        """
+        Add a comment to an issue.
+
+        Args:
+            issue_key: Jira issue key (e.g., PROJ-123)
+            comment_text: Comment text to add
+
+        Returns:
+            Response object with created comment
+        """
+        # Jira Cloud uses Atlassian Document Format (ADF) for comments
+        payload = {
+            "body": {
+                "type": "doc",
+                "version": 1,
+                "content": [
+                    {
+                        "type": "paragraph",
+                        "content": [{"type": "text", "text": comment_text}],
+                    }
+                ],
+            }
+        }
+        response = requests.post(
+            url=f"{self.api_url}/issue/{issue_key}/comment",
+            auth=self.auth,
+            headers=self.headers,
+            json=payload,
+        )
+        return response
+
+    def find_transition_id(self, issue_key, target_status):
+        """
+        Find the transition ID for a target status name.
+
+        Args:
+            issue_key: Jira issue key
+            target_status: Name of the target status (e.g., "In Review", "Done")
+
+        Returns:
+            Transition ID if found, None otherwise
+        """
+        response = self.get_transitions(issue_key)
+        if response.status_code != 200:
+            return None
+
+        transitions = response.json().get("transitions", [])
+        for transition in transitions:
+            if transition["name"].lower() == target_status.lower():
+                return transition["id"]
+            # Also check the target status name
+            if transition.get("to", {}).get("name", "").lower() == target_status.lower():
+                return transition["id"]
+        return None
+
+    def transition_to_status(self, issue_key, target_status):
+        """
+        Transition an issue to a target status by name.
+
+        Args:
+            issue_key: Jira issue key
+            target_status: Name of the target status
+
+        Returns:
+            Tuple of (success: bool, message: str)
+        """
+        transition_id = self.find_transition_id(issue_key, target_status)
+        if transition_id is None:
+            return False, f"No transition found to status '{target_status}'"
+
+        response = self.transition_issue(issue_key, transition_id)
+        if response.status_code == 204:
+            return True, f"Transitioned {issue_key} to {target_status}"
+        else:
+            return False, f"Failed to transition: {response.text}"

--- a/flafl/jsonparser.py
+++ b/flafl/jsonparser.py
@@ -1,62 +1,177 @@
-"""Helper functions for parsing JSON payloads from POST requests to the API."""
+"""Helper functions for parsing JSON payloads from GitHub webhooks."""
+
+import re
 
 from . import exceptions
 
 INVALID_USAGE = exceptions.InvalidUsage
 
-
-def is_connection_test(json_data):
-    """Check if event is just a connection test"""
-    return "test" in json_data
+# Regex pattern for Jira issue keys (e.g., PROJ-123, ABC-1)
+JIRA_KEY_PATTERN = re.compile(r"([A-Z][A-Z0-9]+-\d+)")
 
 
-def get_event_key(json_data, debug_info):
-    """Get eventKey.
+def is_ping_event(json_data):
+    """Check if event is a GitHub ping (connection test)."""
+    return "zen" in json_data and "hook_id" in json_data
 
-    The eventKey is the primary key that defines the event that triggered a
-    webhook.
+
+def get_event_type(json_data, github_event_header, debug_info):
     """
-    if "eventKey" not in json_data:
-        message = "POST method to this endpoint must provide an eventKey"
-        raise INVALID_USAGE(message, status_code=410, payload=debug_info)
-    event_key = json_data["eventKey"]
-    event_key_field = event_key.split(":")
-    if len(event_key_field) < 2:
-        message = "eventKey must contain two or more colon-separated items"
-        raise INVALID_USAGE(message, status_code=410, payload=debug_info)
-    event_trigger = event_key_field[1]
-    return event_key, event_trigger
+    Determine the event type from GitHub webhook payload.
+
+    GitHub webhooks use a combination of X-GitHub-Event header and
+    the 'action' field in the payload.
+
+    Args:
+        json_data: Webhook JSON payload
+        github_event_header: Value of X-GitHub-Event header
+        debug_info: Debug info dict to populate
+
+    Returns:
+        Tuple of (event_type, action)
+        event_type: 'pull_request', 'pull_request_review', 'issue_comment', etc.
+        action: 'opened', 'closed', 'synchronize', 'submitted', etc.
+    """
+    if not github_event_header:
+        message = "Missing X-GitHub-Event header"
+        raise INVALID_USAGE(message, status_code=400, payload=debug_info)
+
+    action = json_data.get("action")
+    return github_event_header, action
 
 
-def verify_pull_request_id(json_data, debug_info):
-    """Look for pullRequest id key."""
+def get_pr_info(json_data, debug_info):
+    """
+    Extract pull request information from webhook payload.
+
+    Args:
+        json_data: Webhook JSON payload
+        debug_info: Debug info dict
+
+    Returns:
+        Dict with PR info: number, title, state, merged, head_sha, base_ref, head_ref,
+                          repo_owner, repo_name, html_url
+    """
+    pr = json_data.get("pull_request")
+    if not pr:
+        message = "Payload does not contain pull_request key"
+        raise INVALID_USAGE(message, status_code=400, payload=debug_info)
+
     try:
-        pull_request_id = str(json_data["pullRequest"]["id"])
-    except TypeError:
-        message = "Pull request event does not contain pullRequest id key"
-        raise INVALID_USAGE(message, status_code=420, payload=debug_info)
-    except KeyError:
-        message = "Pull request event does not contain pullRequest key"
-        raise INVALID_USAGE(message, status_code=420, payload=debug_info)
-    if not pull_request_id.isdigit():
-        message = "Pull Request ID is not an integer"
-        raise INVALID_USAGE(message, status_code=420, payload=debug_info)
-    return pull_request_id
+        pr_info = {
+            "number": pr["number"],
+            "title": pr["title"],
+            "state": pr["state"],
+            "merged": pr.get("merged", False),
+            "head_sha": pr["head"]["sha"],
+            "head_ref": pr["head"]["ref"],
+            "base_ref": pr["base"]["ref"],
+            "repo_owner": pr["base"]["repo"]["owner"]["login"],
+            "repo_name": pr["base"]["repo"]["name"],
+            "html_url": pr["html_url"],
+            "user": pr["user"]["login"],
+        }
+    except KeyError as e:
+        message = f"Pull request payload missing required field: {e}"
+        raise INVALID_USAGE(message, status_code=400, payload=debug_info)
+
+    return pr_info
 
 
-def get_from_ref_latest_commit(json_data, debug_info):
-    """Get latestCommit hash for the fromRef branch."""
-    try:
-        from_ref_latest_commit = json_data["pullRequest"]["fromRef"]["latestCommit"]
-    except KeyError:
-        message = "Pull request event does not contain fromRef key"
-        raise INVALID_USAGE(message, status_code=420, payload=debug_info)
-    except TypeError:
-        message = "Pull request fromRef does not contain latestCommit key"
-        raise INVALID_USAGE(message, status_code=420, payload=debug_info)
-    if not isinstance(from_ref_latest_commit, str) or len(from_ref_latest_commit) != 40:
-        message = "Pull request fromRef latestCommit not a 40-character string"
-        debug_info["type_of_from_ref_latest_commit"] = str(type(from_ref_latest_commit))
-        debug_info["len_of_from_ref_latest_commit"] = len(from_ref_latest_commit)
-        raise INVALID_USAGE(message, status_code=420, payload=debug_info)
-    return from_ref_latest_commit
+def extract_jira_keys(text):
+    """
+    Extract all Jira issue keys from text.
+
+    Looks for patterns like PROJ-123, ABC-1, etc.
+
+    Args:
+        text: String to search for Jira keys
+
+    Returns:
+        List of unique Jira issue keys found
+    """
+    if not text:
+        return []
+    matches = JIRA_KEY_PATTERN.findall(text)
+    return list(set(matches))  # Remove duplicates
+
+
+def extract_jira_keys_from_pr(json_data, debug_info):
+    """
+    Extract Jira keys from PR title, branch name, and commit messages.
+
+    Args:
+        json_data: Webhook JSON payload
+        debug_info: Debug info dict
+
+    Returns:
+        List of unique Jira issue keys found
+    """
+    keys = set()
+
+    pr = json_data.get("pull_request", {})
+
+    # Check PR title
+    title = pr.get("title", "")
+    keys.update(extract_jira_keys(title))
+
+    # Check head branch name
+    head_ref = pr.get("head", {}).get("ref", "")
+    keys.update(extract_jira_keys(head_ref))
+
+    # Check PR body/description
+    body = pr.get("body", "") or ""
+    keys.update(extract_jira_keys(body))
+
+    return list(keys)
+
+
+def is_pr_merged(json_data):
+    """Check if the PR was merged (for closed events)."""
+    pr = json_data.get("pull_request", {})
+    return pr.get("merged", False)
+
+
+def get_review_info(json_data, debug_info):
+    """
+    Extract review information from pull_request_review webhook.
+
+    Args:
+        json_data: Webhook JSON payload
+        debug_info: Debug info dict
+
+    Returns:
+        Dict with review info: state, user, body
+    """
+    review = json_data.get("review")
+    if not review:
+        message = "Payload does not contain review key"
+        raise INVALID_USAGE(message, status_code=400, payload=debug_info)
+
+    return {
+        "state": review.get("state"),  # 'approved', 'changes_requested', 'commented'
+        "user": review.get("user", {}).get("login"),
+        "body": review.get("body", ""),
+    }
+
+
+def get_comment_info(json_data, debug_info):
+    """
+    Extract comment information from issue_comment webhook.
+
+    Args:
+        json_data: Webhook JSON payload
+        debug_info: Debug info dict
+
+    Returns:
+        Dict with comment info: body, user
+    """
+    comment = json_data.get("comment")
+    if not comment:
+        message = "Payload does not contain comment key"
+        raise INVALID_USAGE(message, status_code=400, payload=debug_info)
+
+    return {
+        "body": comment.get("body", ""),
+        "user": comment.get("user", {}).get("login"),
+    }

--- a/tests/test_flafl.py
+++ b/tests/test_flafl.py
@@ -1,9 +1,9 @@
 """
 Tests for the main program.
 
-These tests simulate how the program behaves.
-
+These tests simulate how the program behaves with GitHub webhook payloads.
 """
+
 import pytest
 import flafl
 
@@ -18,40 +18,80 @@ def client():
     yield client
 
 
-def test_connection_test(client):
-    rv = client.post(endpoint, json={"test": "true"})
-    json_data = rv.get_json()
-    assert json_data["message"] == "Successful connection."
-
-
-def test_no_eventKey(client):
-    rv = client.post(endpoint, json={"a": 1})
-    json_data = rv.get_json()
-    assert (
-        json_data["message"] == "POST method to this endpoint must provide an eventKey"
+def test_ping_event(client):
+    """Test GitHub ping event (webhook setup verification)."""
+    rv = client.post(
+        endpoint,
+        json={"zen": "Keep it simple.", "hook_id": 12345},
+        headers={"X-GitHub-Event": "ping"},
     )
-
-
-def test_bad_eventKey(client):
-    rv = client.post(endpoint, json={"eventKey": "1"})
     json_data = rv.get_json()
-    assert (
-        json_data["message"]
-        == "eventKey must contain two or more colon-separated items"
+    assert json_data["status"] == "success"
+    assert "Pong!" in json_data["message"]
+    assert json_data["hook_id"] == 12345
+
+
+def test_missing_github_event_header(client):
+    """Test request without X-GitHub-Event header."""
+    rv = client.post(endpoint, json={"action": "opened"})
+    json_data = rv.get_json()
+    assert "Missing X-GitHub-Event header" in json_data["message"]
+
+
+def test_health_check(client):
+    """Test health check endpoint."""
+    rv = client.get("/flafl/api/v1.0/health")
+    json_data = rv.get_json()
+    assert json_data["status"] == "healthy"
+
+
+def test_unhandled_event(client):
+    """Test unhandled event type."""
+    rv = client.post(
+        endpoint,
+        json={"action": "created"},
+        headers={"X-GitHub-Event": "unknown_event"},
     )
-
-
-def test_notCodedYet_2(client):
-    rv = client.post(endpoint, json={"eventKey": "anything:anything"})
     json_data = rv.get_json()
-    assert json_data["message"] == "Trigger-handling for eventKey not coded yet"
+    assert json_data["status"] == "success"
+    assert "unhandled event" in json_data["message"].lower()
 
 
-class TestClass(object):
-    def test_one(self):
-        x = "this"
-        assert "h" in x
+class TestJiraKeyExtraction:
+    """Tests for Jira key extraction from text."""
 
-    def test_two(self):
-        x = "hello"
-        assert not hasattr(x, "check")
+    def test_extract_single_key(self):
+        from flafl.jsonparser import extract_jira_keys
+
+        keys = extract_jira_keys("PROJ-123: Add new feature")
+        assert keys == ["PROJ-123"]
+
+    def test_extract_multiple_keys(self):
+        from flafl.jsonparser import extract_jira_keys
+
+        keys = extract_jira_keys("PROJ-123, ABC-456: Fix bugs")
+        assert set(keys) == {"PROJ-123", "ABC-456"}
+
+    def test_extract_no_keys(self):
+        from flafl.jsonparser import extract_jira_keys
+
+        keys = extract_jira_keys("Add new feature without ticket")
+        assert keys == []
+
+    def test_extract_from_branch_name(self):
+        from flafl.jsonparser import extract_jira_keys
+
+        keys = extract_jira_keys("feature/PROJ-789-add-login")
+        assert keys == ["PROJ-789"]
+
+    def test_extract_empty_string(self):
+        from flafl.jsonparser import extract_jira_keys
+
+        keys = extract_jira_keys("")
+        assert keys == []
+
+    def test_extract_none(self):
+        from flafl.jsonparser import extract_jira_keys
+
+        keys = extract_jira_keys(None)
+        assert keys == []

--- a/tests/test_pr.py
+++ b/tests/test_pr.py
@@ -1,9 +1,9 @@
 """
-Tests for the .
+Tests for pull request webhook handling.
 
-These tests simulate how the program behaves when a pull request payload is provided.
-
+These tests simulate GitHub pull request webhook payloads.
 """
+
 import pytest
 import flafl
 
@@ -18,303 +18,236 @@ def client():
     yield client
 
 
-def test_unrecognised_pr_trigger(client):
-    rv = client.post(endpoint, json={"eventKey": "pr:null"})
-    json_data = rv.get_json()
-    assert json_data["message"] == "Trigger-handling for eventKey not coded yet"
-
-
-def test_notCodedYet_1(client):
-    rv = client.post(
-        endpoint,
-        json={
-            "eventKey": "pr:notcoded",
-            "pullRequest": {
-                "id": 1,
-                "fromRef": {"latestCommit": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"},
+def make_pr_payload(action="opened", number=1, title="PROJ-123: Test PR", merged=False):
+    """Helper to create a valid GitHub PR webhook payload."""
+    return {
+        "action": action,
+        "number": number,
+        "pull_request": {
+            "number": number,
+            "title": title,
+            "state": "closed" if action == "closed" else "open",
+            "merged": merged,
+            "html_url": f"https://github.com/owner/repo/pull/{number}",
+            "user": {"login": "testuser"},
+            "head": {
+                "sha": "abc1234567890123456789012345678901234567",
+                "ref": "feature/PROJ-123-new-feature",
+            },
+            "base": {
+                "ref": "main",
+                "repo": {
+                    "name": "test-repo",
+                    "owner": {"login": "test-owner"},
+                },
             },
         },
-    )
-    json_data = rv.get_json()
-    assert json_data["message"] == "Trigger-handling for eventKey not coded yet"
+    }
 
 
 # Tests for opened pull requests
 # ------------------------------
 
 
-def test_no_pullRequestKey(client):
-    rv = client.post(endpoint, json={"eventKey": "pr:opened"})
-    json_data = rv.get_json()
-    assert json_data["message"] == "Pull request event does not contain pullRequest key"
-
-
-def test_no_pullRequestId(client):
-    rv = client.post(endpoint, json={"eventKey": "pr:opened", "pullRequest": "null"})
-    json_data = rv.get_json()
-    assert (
-        json_data["message"] == "Pull request event does not contain pullRequest id key"
-    )
-
-
-def test_bad_pullRequestId(client):
-    rv = client.post(
-        endpoint, json={"eventKey": "pr:opened", "pullRequest": {"id": "null"}}
-    )
-    json_data = rv.get_json()
-    assert json_data["message"] == "Pull Request ID is not an integer"
-
-
-def test_valid_pr_opened(client):
+def test_pr_opened_with_jira_key(client):
+    """Test PR opened event with Jira key in title."""
+    payload = make_pr_payload(action="opened", title="PROJ-123: Add new feature")
     rv = client.post(
         endpoint,
-        json={
-            "eventKey": "pr:opened",
-            "pullRequest": {
-                "id": "1",
-                "title": "pull request title",
-                "state": "OPEN",
-                "fromRef": {
-                    "displayId": "feature-branch-name",
-                    "repository": {"slug": "fork-name", "project": {"key": "~user"}},
-                },
-                "toRef": {
-                    "displayId": "develop",
-                    "repository": {"slug": "repo-name", "project": {"key": "project"}},
-                },
-            },
-        },
+        json=payload,
+        headers={"X-GitHub-Event": "pull_request"},
     )
     json_data = rv.get_json()
     assert json_data["status"] == "success"
-    assert (
-        json_data["message"]
-        == "Created PR with ID 1 from ~user/fork-name/feature-branch-name to project/repo-name/develop. Sent API call to Bamboo and got return code 204"
-        or json_data["message"]
-        == "Created PR with ID 1 from ~user/fork-name/feature-branch-name to project/repo-name/develop. API call to Bamboo not made."
-    )
+    assert "PROJ-123" in json_data["jira_keys"]
+    assert "opened" in json_data["message"].lower()
 
 
-# Tests for modified pull requests
-# --------------------------------
-
-
-def test_no_fromRef(client):
+def test_pr_opened_without_jira_key(client):
+    """Test PR opened event without Jira key triggers comment."""
+    payload = make_pr_payload(action="opened", title="Add new feature without ticket")
     rv = client.post(
         endpoint,
-        json={
-            "eventKey": "pr:modified",
-            "pullRequest": {
-                "id": "1",
-                "title": "pull request title",
-                "toRef": {
-                    "displayId": "develop",
-                    "repository": {"slug": "repo-name", "project": {"key": "project"}},
-                },
-            },
-        },
-    )
-    json_data = rv.get_json()
-    assert json_data["message"] == "Pull request event does not contain fromRef key"
-
-
-def test_no_latestCommit(client):
-    rv = client.post(
-        endpoint,
-        json={
-            "eventKey": "pr:modified",
-            "pullRequest": {
-                "id": 1,
-                "title": "pull request title",
-                "fromRef": "null",
-                "toRef": {
-                    "displayId": "develop",
-                    "repository": {"slug": "repo-name", "project": {"key": "project"}},
-                },
-            },
-        },
-    )
-    json_data = rv.get_json()
-    assert (
-        json_data["message"] == "Pull request fromRef does not contain latestCommit key"
-    )
-
-
-def test_bad_latestCommit(client):
-    rv = client.post(
-        endpoint,
-        json={
-            "eventKey": "pr:modified",
-            "pullRequest": {
-                "id": 1,
-                "title": "pull request title",
-                "fromRef": {"latestCommit": "1"},
-                "toRef": {
-                    "displayId": "develop",
-                    "repository": {"slug": "repo-name", "project": {"key": "project"}},
-                },
-            },
-        },
-    )
-    json_data = rv.get_json()
-    assert (
-        json_data["message"]
-        == "Pull request fromRef latestCommit not a 40-character string"
-    )
-
-
-def test_valid_pr_modified(client):
-    rv = client.post(
-        endpoint,
-        json={
-            "eventKey": "pr:modified",
-            "pullRequest": {
-                "id": "1",
-                "fromRef": {"latestCommit": "1234567890123456789012345678901234567890"},
-            },
-        },
+        json=payload,
+        headers={"X-GitHub-Event": "pull_request"},
     )
     json_data = rv.get_json()
     assert json_data["status"] == "success"
+    assert json_data["jira_keys"] == []
+    assert "No Jira keys found" in str(json_data["results"])
 
 
-def test_valid_pr_modified(client):
+def test_pr_opened_jira_key_in_branch(client):
+    """Test PR opened event with Jira key only in branch name."""
+    payload = make_pr_payload(action="opened", title="Add new feature")
+    # Branch already contains PROJ-123 in head ref
     rv = client.post(
         endpoint,
-        json={
-            "eventKey": "pr:modified",
-            "pullRequest": {
-                "id": "1",
-                "title": "pull request title",
-                "fromRef": {
-                    "displayId": "feature-branch-name",
-                    "latestCommit": "1234567890123456789012345678901234567890",
-                    "repository": {"slug": "fork-name", "project": {"key": "~user"}},
-                },
-                "toRef": {
-                    "displayId": "develop",
-                    "repository": {"slug": "repo-name", "project": {"key": "project"}},
-                },
-            },
-        },
+        json=payload,
+        headers={"X-GitHub-Event": "pull_request"},
     )
     json_data = rv.get_json()
     assert json_data["status"] == "success"
-    assert json_data["payload"] == "1234567890123456789012345678901234567890"
+    assert "PROJ-123" in json_data["jira_keys"]
 
 
-# Tests for pull request comments
-# -------------------------------
-
-
-def test_no_comment(client):
-    rv = client.post(
-        endpoint, json={"eventKey": "pr:comment", "pullRequest": {"id": "1"}}
-    )
-    json_data = rv.get_json()
-    assert (
-        json_data["message"] == "Payload for comment event did not contain comment key"
-    )
-
-
-def test_no_author(client):
+def test_pr_reopened(client):
+    """Test PR reopened event."""
+    payload = make_pr_payload(action="reopened", title="PROJ-456: Reopened PR")
     rv = client.post(
         endpoint,
-        json={
-            "eventKey": "pr:comment",
-            "pullRequest": {"id": "1"},
-            "comment": {"a": "null"},
-        },
-    )
-    json_data = rv.get_json()
-    assert (
-        json_data["message"] == "Payload for comment event did not contain author key"
-    )
-
-
-def test_no_name(client):
-    rv = client.post(
-        endpoint,
-        json={
-            "eventKey": "pr:comment",
-            "pullRequest": {"id": "1"},
-            "comment": {"author": "null"},
-        },
-    )
-    json_data = rv.get_json()
-    assert json_data["message"] == "Payload for comment event did not contain name key"
-
-
-def test_valid_pr_comment_modified(client):
-    rv = client.post(
-        endpoint,
-        json={
-            "eventKey": "pr:comment:modified",
-            "pullRequest": {"id": "1"},
-            "comment": {"author": {"name": "xxxx"}},
-        },
+        json=payload,
+        headers={"X-GitHub-Event": "pull_request"},
     )
     json_data = rv.get_json()
     assert json_data["status"] == "success"
+    assert "PROJ-456" in json_data["jira_keys"]
 
 
-def test_valid_pr_comment_deleted(client):
+def test_pr_missing_pull_request_key(client):
+    """Test PR event without pull_request key."""
     rv = client.post(
         endpoint,
-        json={
-            "eventKey": "pr:comment:deleted",
-            "pullRequest": {"id": "1"},
-            "comment": {"author": {"name": "xxxx"}},
-        },
+        json={"action": "opened"},
+        headers={"X-GitHub-Event": "pull_request"},
+    )
+    json_data = rv.get_json()
+    assert "does not contain pull_request key" in json_data["message"]
+
+
+# Tests for closed/merged pull requests
+# -------------------------------------
+
+
+def test_pr_merged(client):
+    """Test PR merged event."""
+    payload = make_pr_payload(action="closed", title="PROJ-789: Merged PR", merged=True)
+    rv = client.post(
+        endpoint,
+        json=payload,
+        headers={"X-GitHub-Event": "pull_request"},
     )
     json_data = rv.get_json()
     assert json_data["status"] == "success"
+    assert json_data["merged"] is True
+    assert "PROJ-789" in json_data["jira_keys"]
+    assert "merged" in json_data["message"].lower()
 
 
-# Tests for removed pull requests
-# -------------------------------
+def test_pr_closed_not_merged(client):
+    """Test PR closed without merge."""
+    payload = make_pr_payload(action="closed", title="PROJ-999: Closed PR", merged=False)
+    rv = client.post(
+        endpoint,
+        json=payload,
+        headers={"X-GitHub-Event": "pull_request"},
+    )
+    json_data = rv.get_json()
+    assert json_data["status"] == "success"
+    assert json_data["merged"] is False
+    assert "closed" in json_data["message"].lower()
 
 
-class TestPrDestroyed(object):
-    def pr_destroyed(self, client, trigger):
-        rv = client.post(
-            endpoint,
-            json={
-                "eventKey": "pr:" + trigger,
-                "pullRequest": {
-                    "id": "1",
-                    "fromRef": {
-                        "displayId": "feature-branch-name",
-                        "repository": {
-                            "slug": "fork-name",
-                            "project": {"key": "~user"},
-                        },
-                    },
-                    "toRef": {
-                        "displayId": "develop",
-                        "repository": {
-                            "slug": "repo-name",
-                            "project": {"key": "project"},
-                        },
-                    },
-                },
-            },
-        )
-        json_data = rv.get_json()
-        assert json_data["status"] == "success"
-        assert (
-            json_data["message"]
-            == "Destroyed PR with ID 1 in repository ~user/repo-name"
-        )
+# Tests for synchronized pull requests
+# ------------------------------------
 
-    def test_valid_pr_deleted(self, client):
-        trigger = "deleted"
-        self.pr_destroyed(client, trigger)
 
-    def test_valid_pr_merged(self, client):
-        trigger = "merged"
-        self.pr_destroyed(client, trigger)
+def test_pr_synchronized(client):
+    """Test PR synchronized event (new commits pushed)."""
+    payload = make_pr_payload(action="synchronize", title="PROJ-111: Updated PR")
+    rv = client.post(
+        endpoint,
+        json=payload,
+        headers={"X-GitHub-Event": "pull_request"},
+    )
+    json_data = rv.get_json()
+    assert json_data["status"] == "success"
+    assert "synchronized" in json_data["message"].lower()
+    assert "head_sha" in json_data
 
-    def test_valid_pr_declined(self, client):
-        trigger = "declined"
-        self.pr_destroyed(client, trigger)
+
+# Tests for pull request reviews
+# ------------------------------
+
+
+def test_pr_review_approved(client):
+    """Test PR review approved event."""
+    payload = make_pr_payload(action="submitted", title="PROJ-222: Review PR")
+    payload["review"] = {
+        "state": "approved",
+        "user": {"login": "reviewer"},
+        "body": "LGTM!",
+    }
+    rv = client.post(
+        endpoint,
+        json=payload,
+        headers={"X-GitHub-Event": "pull_request_review"},
+    )
+    json_data = rv.get_json()
+    assert json_data["status"] == "success"
+    assert json_data["review_state"] == "approved"
+    assert json_data["reviewer"] == "reviewer"
+
+
+def test_pr_review_changes_requested(client):
+    """Test PR review with changes requested."""
+    payload = make_pr_payload(action="submitted", title="PROJ-333: Needs work")
+    payload["review"] = {
+        "state": "changes_requested",
+        "user": {"login": "reviewer"},
+        "body": "Please fix the tests.",
+    }
+    rv = client.post(
+        endpoint,
+        json=payload,
+        headers={"X-GitHub-Event": "pull_request_review"},
+    )
+    json_data = rv.get_json()
+    assert json_data["status"] == "success"
+    assert json_data["review_state"] == "changes_requested"
+
+
+# Tests for issue comments (PR comments)
+# --------------------------------------
+
+
+def test_pr_comment(client):
+    """Test comment on PR."""
+    payload = {
+        "action": "created",
+        "issue": {
+            "number": 1,
+            "title": "PROJ-444: PR with comment",
+            "pull_request": {},  # Indicates this is a PR, not an issue
+        },
+        "comment": {
+            "body": "This is a comment",
+            "user": {"login": "commenter"},
+        },
+    }
+    rv = client.post(
+        endpoint,
+        json=payload,
+        headers={"X-GitHub-Event": "issue_comment"},
+    )
+    json_data = rv.get_json()
+    assert json_data["status"] == "success"
+    assert json_data["commenter"] == "commenter"
+    assert "PROJ-444" in json_data["jira_keys"]
+
+
+# Tests for unhandled PR actions
+# ------------------------------
+
+
+def test_pr_edited(client):
+    """Test PR edited action (currently unhandled)."""
+    payload = make_pr_payload(action="edited", title="PROJ-555: Edited PR")
+    rv = client.post(
+        endpoint,
+        json=payload,
+        headers={"X-GitHub-Event": "pull_request"},
+    )
+    json_data = rv.get_json()
+    assert json_data["status"] == "success"
+    assert "unhandled" in json_data["message"].lower()

--- a/tests/test_pr.py
+++ b/tests/test_pr.py
@@ -65,7 +65,30 @@ def test_pr_opened_with_jira_key(client):
 
 def test_pr_opened_without_jira_key(client):
     """Test PR opened event without Jira key triggers comment."""
-    payload = make_pr_payload(action="opened", title="Add new feature without ticket")
+    # Create payload without Jira key in title or branch
+    payload = {
+        "action": "opened",
+        "number": 1,
+        "pull_request": {
+            "number": 1,
+            "title": "Add new feature without ticket",
+            "state": "open",
+            "merged": False,
+            "html_url": "https://github.com/owner/repo/pull/1",
+            "user": {"login": "testuser"},
+            "head": {
+                "sha": "abc1234567890123456789012345678901234567",
+                "ref": "feature/add-new-feature",  # No Jira key in branch
+            },
+            "base": {
+                "ref": "main",
+                "repo": {
+                    "name": "test-repo",
+                    "owner": {"login": "test-owner"},
+                },
+            },
+        },
+    }
     rv = client.post(
         endpoint,
         json=payload,

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -1,9 +1,9 @@
 """
-Tests for the .
+Tests for repository webhook handling.
 
-These tests simulate how the program behaves when a repository payload is provided.
-
+These tests simulate GitHub push event payloads.
 """
+
 import pytest
 import flafl
 
@@ -18,7 +18,64 @@ def client():
     yield client
 
 
-def test_notCodedYet_3(client):
-    rv = client.post(endpoint, json={"eventKey": "repo:anything"})
+def test_push_event_with_jira_keys(client):
+    """Test push event extracts Jira keys from commit messages."""
+    rv = client.post(
+        endpoint,
+        json={
+            "ref": "refs/heads/main",
+            "commits": [
+                {"message": "PROJ-123: Add new feature"},
+                {"message": "PROJ-456: Fix bug"},
+            ],
+            "repository": {
+                "name": "test-repo",
+                "owner": {"login": "test-owner"},
+            },
+        },
+        headers={"X-GitHub-Event": "push"},
+    )
     json_data = rv.get_json()
-    assert json_data["message"] == "Trigger-handling for eventKey not coded yet"
+    assert json_data["status"] == "success"
+    assert "push" in json_data["message"].lower()
+    assert set(json_data["jira_keys"]) == {"PROJ-123", "PROJ-456"}
+    assert json_data["commit_count"] == 2
+
+
+def test_push_event_without_jira_keys(client):
+    """Test push event without Jira keys in commits."""
+    rv = client.post(
+        endpoint,
+        json={
+            "ref": "refs/heads/feature-branch",
+            "commits": [
+                {"message": "Add new feature"},
+                {"message": "Fix bug"},
+            ],
+            "repository": {
+                "name": "test-repo",
+            },
+        },
+        headers={"X-GitHub-Event": "push"},
+    )
+    json_data = rv.get_json()
+    assert json_data["status"] == "success"
+    assert json_data["jira_keys"] == []
+
+
+def test_push_event_empty_commits(client):
+    """Test push event with no commits (e.g., branch deletion)."""
+    rv = client.post(
+        endpoint,
+        json={
+            "ref": "refs/heads/deleted-branch",
+            "commits": [],
+            "repository": {
+                "name": "test-repo",
+            },
+        },
+        headers={"X-GitHub-Event": "push"},
+    )
+    json_data = rv.get_json()
+    assert json_data["status"] == "success"
+    assert json_data["commit_count"] == 0


### PR DESCRIPTION
Replace Bitbucket/Bamboo integration with GitHub/Jira:
- Add jira.py: Jira Cloud API client for transitions and comments
- Add github.py: GitHub API client for PR comments
- Update jsonparser.py: Parse GitHub webhook payloads, extract Jira keys
- Update strategies.py: New strategies for PR opened/closed/merged/reviewed
- Update __init__.py: Route GitHub events to appropriate strategies
- Update helpers.py: Jira transition and GitHub comment helpers
- Update context.py: Support config parameter in strategy execution
- Update tests: New test suite for GitHub webhook handling

Supported events:
- pull_request: opened, reopened, closed, synchronize
- pull_request_review: submitted (approved, changes_requested)
- issue_comment: created
- push: extract Jira keys from commit messages
- ping: webhook setup verification

https://claude.ai/code/session_01Gj2DheFPhzqvwFJkE1tTok